### PR TITLE
use a absolute path with radiate

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -13,6 +13,8 @@ mist = ">= 5.0.3 and < 6.0.0"
 gleam_erlang = ">= 1.3.0 and < 2.0.0"
 gleam_http = ">= 4.2.0 and < 5.0.0"
 gleam_otp = ">= 1.1.0 and < 2.0.0"
+filepath = ">= 1.1.2 and < 2.0.0"
+simplifile = ">= 2.4.0 and < 3.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,6 +3,7 @@
 
 packages = [
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "filespy", version = "0.7.0", build_tools = ["gleam"], requirements = ["fs", "gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "filespy", source = "hex", outer_checksum = "1136C7DB512B83DF544CDA4632A633412281B48489428391DB0356F66423D7C0" },
   { name = "fs", version = "11.4.1", build_tools = ["rebar3"], requirements = [], otp_app = "fs", source = "hex", outer_checksum = "DD00A61D89EAC01D16D3FC51D5B0EB5F0722EF8E3C1A3A547CD086957F3260A9" },
   { name = "gleam_crypto", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "50774BAFFF1144E7872814C566C5D653D83A3EBF23ACC3156B757A1B6819086E" },
@@ -19,10 +20,12 @@ packages = [
   { name = "mist", version = "5.0.3", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "gleam_yielder", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "7C4BE717A81305323C47C8A591E6B9BA4AC7F56354BF70B4D3DF08CC01192668" },
   { name = "radiate", version = "1.0.0", build_tools = ["gleam"], requirements = ["filespy", "gleam_erlang", "gleam_otp", "gleam_stdlib", "shellout"], otp_app = "radiate", source = "hex", outer_checksum = "AB86888E56C463641771AC21BB75464E19B848E733289BD6D78E562F6FA7C121" },
   { name = "shellout", version = "1.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "shellout", source = "hex", outer_checksum = "1BDC03438FEB97A6AF3E396F4ABEB32BECF20DF2452EC9A8C0ACEB7BDDF70B14" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "telemetry", version = "1.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "7015FC8919DBE63764F4B4B87A95B7C0996BD539E0D499BE6EC9D7F3875B79E6" },
 ]
 
 [requirements]
+filepath = { version = ">= 1.1.2 and < 2.0.0" }
 gleam_erlang = { version = ">= 1.3.0 and < 2.0.0" }
 gleam_http = { version = ">= 4.2.0 and < 5.0.0" }
 gleam_otp = { version = ">= 1.1.0 and < 2.0.0" }
@@ -30,3 +33,4 @@ gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 mist = { version = ">= 5.0.3 and < 6.0.0" }
 radiate = { version = ">= 1.0.0 and < 2.0.0" }
+simplifile = { version = ">= 2.4.0 and < 3.0.0" }

--- a/src/mist/reload.gleam
+++ b/src/mist/reload.gleam
@@ -1,3 +1,4 @@
+import filepath
 import gleam/bit_array
 import gleam/bytes_tree
 import gleam/erlang/process
@@ -9,6 +10,7 @@ import gleam/string
 import gleam/string_tree
 import mist
 import radiate
+import simplifile
 
 type Message(t) {
   Register(subscriber: process.Subject(t), reply: process.Subject(Nil))
@@ -33,9 +35,12 @@ pub fn wrap(handler) {
     })
     |> actor.start()
 
+  let assert Ok(current_directory) = simplifile.current_directory()
+  let src_directory = filepath.join(current_directory, "src")
+
   let _ =
     radiate.new()
-    |> radiate.add_dir("src")
+    |> radiate.add_dir(src_directory)
     |> radiate.on_reload(fn(_state: Nil, _file) {
       actor.send(registry.data, Broadcast(Reloaded))
     })


### PR DESCRIPTION
This will use `simplifile` and `filepath` to construct an absolute path. It should behave the same way with the added bonus that it works on OS X. (See #1 ).



An alternative if you don't fancy the dependencies could be to somehow let users pass in the paths they want to trigger reloads.